### PR TITLE
fix(ui): show read-only honor status without update permission

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@fortawesome/vue-fontawesome": "^3.1.3",
     "@microsoft/applicationinsights-web": "^3.3.11",
     "@vue/tsconfig": "^0.8.1",
-    "axios": "^1.13.2",
+    "axios": "^1.13.3",
     "fontawesome": "^5.6.3",
     "jwt-decode": "^4.0.0",
     "pinia": "3.0.4",
@@ -65,7 +65,7 @@
     "typescript": "~5.9.3",
     "vite": "^7.3.0",
     "vitest": "^4.0.18",
-    "vue-tsc": "^3.2.3"
+    "vue-tsc": "^3.2.4"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@fortawesome/vue-fontawesome": "^3.1.3",
     "@microsoft/applicationinsights-web": "^3.3.11",
     "@vue/tsconfig": "^0.8.1",
-    "axios": "^1.13.3",
+    "axios": "^1.13.4",
     "fontawesome": "^5.6.3",
     "jwt-decode": "^4.0.0",
     "pinia": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@semantic-release/release-notes-generator": "^14.1.0",
     "@types/jsdom": "^27.0.0",
     "@types/lodash": "^4.17.23",
-    "@types/node": "^25.0.10",
+    "@types/node": "^25.1.0",
     "@vitejs/plugin-vue": "^6.0.3",
     "@vitest/coverage-v8": "^4.0.18",
     "@vue/eslint-config-prettier": "^10.2.0",

--- a/src/components/PathfinderHonorComponent.vue
+++ b/src/components/PathfinderHonorComponent.vue
@@ -18,6 +18,7 @@
       
       <div class="status-dropdown">
         <div
+          v-if="canUpdatePathfinder"
           class="status-selector"
           :class="newStatus.toLowerCase()"
           @click="showDropdown = !showDropdown"
@@ -25,9 +26,16 @@
           <span>{{ newStatus }}</span>
           <span class="dropdown-arrow">▼</span>
         </div>
+        <div
+          v-else
+          class="status-display"
+          :class="newStatus.toLowerCase()"
+        >
+          <span>{{ newStatus }}</span>
+        </div>
         
         <div
-          v-if="showDropdown"
+          v-if="canUpdatePathfinder && showDropdown"
           class="dropdown-options"
         >
           <div 
@@ -225,6 +233,16 @@ export default defineComponent({
   color: white;
   font-weight: bold;
   cursor: pointer;
+}
+
+.status-display {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 15px;
+  border-radius: 5px;
+  color: white;
+  font-weight: bold;
 }
 
 .dropdown-arrow {

--- a/src/components/__tests__/PathfinderHonorComponent.spec.ts
+++ b/src/components/__tests__/PathfinderHonorComponent.spec.ts
@@ -63,6 +63,13 @@ describe('PathfinderHonorComponent', () => {
       expect(wrapper.find('.honor-card').exists()).toBe(false)
     })
 
+    it('renders read-only status when user cannot update pathfinder', async () => {
+      await wrapper.setProps({ canUpdatePathfinder: false })
+      expect(wrapper.find('.status-selector').exists()).toBe(false)
+      expect(wrapper.find('.status-display').exists()).toBe(true)
+      expect(wrapper.find('button').exists()).toBe(false)
+    })
+
     it('renders status selector with correct options', async () => {
       const statusSelector = wrapper.find('.status-selector')
       expect(statusSelector.exists()).toBe(true)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1669,10 +1669,10 @@
     typescript-eslint "^8.35.1"
     vue-eslint-parser "^10.2.0"
 
-"@vue/language-core@3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@vue/language-core/-/language-core-3.2.3.tgz#e9d8765e202a4ab5bc72a6ac8807e8796c03404f"
-  integrity sha512-VpN/GnYDzGLh44AI6i1OB/WsLXo6vwnl0EWHBelGc4TyC0yEq6azwNaed/+Tgr8anFlSdWYnMEkyHJDPe7ii7A==
+"@vue/language-core@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vue/language-core/-/language-core-3.2.4.tgz#03bb7a67ab8639fabb2cc4e49360fc742e99816a"
+  integrity sha512-bqBGuSG4KZM45KKTXzGtoCl9cWju5jsaBKaJJe3h5hRAAWpZUuj5G+L+eI01sPIkm4H6setKRlw7E85wLdDNew==
   dependencies:
     "@volar/language-core" "2.4.27"
     "@vue/compiler-dom" "^3.5.0"
@@ -1886,10 +1886,10 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.13.2:
-  version "1.13.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.2.tgz#9ada120b7b5ab24509553ec3e40123521117f687"
-  integrity sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==
+axios@^1.13.3:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.3.tgz#f123e77356630a22b0163920662556944f2be1a1"
+  integrity sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.4"
@@ -4031,11 +4031,6 @@ mitt@^3.0.1:
   resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
   integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
-mkdirp@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-3.0.1.tgz#e44e4c5607fb279c168241713cc6e0fea9adcb50"
-  integrity sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==
-
 ms@^2.1.2, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
@@ -5715,13 +5710,13 @@ vue-router@^4.6.4:
   dependencies:
     "@vue/devtools-api" "^6.6.4"
 
-vue-tsc@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-3.2.3.tgz#a2bc15955b5b21a2826b9a89930001fc8e369193"
-  integrity sha512-1RdRB7rQXGFMdpo0aXf9spVzWEPGAk7PEb/ejHQwVrcuQA/HsGiixIc3uBQeqY2YjeEEgvr2ShQewBgcN4c1Cw==
+vue-tsc@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-3.2.4.tgz#a8cebd4b44e6804a99f4d88a8161a4bfb293c3b4"
+  integrity sha512-xj3YCvSLNDKt1iF9OcImWHhmYcihVu9p4b9s4PGR/qp6yhW+tZJaypGxHScRyOrdnHvaOeF+YkZOdKwbgGvp5g==
   dependencies:
     "@volar/typescript" "2.4.27"
-    "@vue/language-core" "3.2.3"
+    "@vue/language-core" "3.2.4"
 
 vue3-simple-typeahead@^1.0.11:
   version "1.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,10 +1886,10 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.13.3:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.3.tgz#f123e77356630a22b0163920662556944f2be1a1"
-  integrity sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==
+axios@^1.13.4:
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.4.tgz#15d109a4817fb82f73aea910d41a2c85606076bc"
+  integrity sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,10 +1357,10 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.23.tgz#c1bb06db218acc8fc232da0447473fc2fb9d9841"
   integrity sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA==
 
-"@types/node@*", "@types/node@^25.0.10":
-  version "25.0.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.0.10.tgz#4864459c3c9459376b8b75fd051315071c8213e7"
-  integrity sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==
+"@types/node@*", "@types/node@^25.1.0":
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.1.0.tgz#95cc584f1f478301efc86de4f1867e5875e83571"
+  integrity sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==
   dependencies:
     undici-types "~7.16.0"
 


### PR DESCRIPTION
## Summary
- hide the interactive honor status dropdown when the user cannot update a pathfinder
- render a read-only status display instead so status remains informational
- keep Update Status action unavailable for users without permission

## Testing
- `yarn vitest run src/components/__tests__/PathfinderHonorComponent.spec.ts`